### PR TITLE
Forward flags and isGroup to Dart so that group notifications can be ignored

### DIFF
--- a/android/src/main/kotlin/im/zoe/labs/flutter_notification_listener/NotificationEvent.kt
+++ b/android/src/main/kotlin/im/zoe/labs/flutter_notification_listener/NotificationEvent.kt
@@ -32,6 +32,8 @@ class NotificationEvent(context: Context, sbn: StatusBarNotification) {
         private const val NOTIFICATION_CAN_TAP = "canTap"
         private const val NOTIFICATION_KEY = "key"
         private const val NOTIFICATION_UNIQUE_ID = "_id"
+        private const val NOTIFICATION_FLAGS = "flags"
+        private const val NOTIFICATION_IS_GROUP = "isGroup"
 
         fun genKey(vararg items: Any?): String {
             return Utils.md5(items.joinToString(separator="-"){ "$it" }).slice(IntRange(0, 12))
@@ -54,6 +56,9 @@ class NotificationEvent(context: Context, sbn: StatusBarNotification) {
 
             map[NOTIFICATION_IS_CLEARABLE] = sbn.isClearable
             map[NOTIFICATION_PRIORITY] = notify?.priority ?: Notification.PRIORITY_DEFAULT
+
+            map[NOTIFICATION_FLAGS] = notify.flags
+            map[NOTIFICATION_IS_GROUP] = (notify.flags and Notification.FLAG_GROUP_SUMMARY) != 0
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                 map[NOTIFICATION_UID] = sbn.uid

--- a/lib/src/event.dart
+++ b/lib/src/event.dart
@@ -158,6 +158,10 @@ class NotificationEvent {
 
   int? priority;
 
+  int? flags;
+
+  bool? isGroup;
+
   /// the raw notifaction data from android
   dynamic _data;
 
@@ -179,6 +183,8 @@ class NotificationEvent {
     this.canTap,
     this.isClearable,
     this.priority,
+    this.flags,
+    this.isGroup,
   });
 
   Map<dynamic, dynamic>? get raw => _data;
@@ -205,6 +211,8 @@ class NotificationEvent {
       canTap: map["canTap"],
       isClearable: map["isClearable"],
       priority: map["priority"],
+      flags: map["flags"],
+      isGroup: map["isGroup"],
     );
 
     // set the raw data


### PR DESCRIPTION
Currently the package ignores whether the notification is a group notification. As a result we get duplicate notifications. This helps the app identify and ignore group notifications. 