### PR TITLE
fix NullPointerException sometimes thrown by label field

### DIFF
--- a/android/src/main/kotlin/im/zoe/labs/flutter_notification_listener/NotificationEvent.kt
+++ b/android/src/main/kotlin/im/zoe/labs/flutter_notification_listener/NotificationEvent.kt
@@ -166,7 +166,7 @@ class NotificationEvent(context: Context, sbn: StatusBarNotification) {
                     if (act.remoteInputs != null) {
                         act.remoteInputs.forEach {
                             val input = HashMap<String, Any>()
-                            input["label"] = it.label.toString()
+                            input["label"] = it.label?.toString() ?: ""
                             input["key"] = it.resultKey
                             // input["choices"] = it.choices
                             ins = ins + input


### PR DESCRIPTION
This happens to be the only fix upstream that we are missing https://github.com/jiusanzhou/flutter_notification_listener/issues/37

And we are having this issue in our Crashlytics logs. https://console.firebase.google.com/project/moto-watch-v2/crashlytics/app/android:ca.cebrands.motowatch/issues/7a25a17d5975d225092f52ad0285091f?time=last-seven-days&types=crash&sessionEventKey=65A6F4D000E900014CC4A06D0858AEB2_1903494899809120689

Hopefully this will fix it. 